### PR TITLE
Added support for SkyQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,23 @@ remoteControl.press('channelup', function(err) {
 });
 
 ```
+### Sky Q
+
+```
+var remoteControl = new SkyRemote('192.168.0.40', SkyRemote.SKY_Q);
+```
 
 ## Remote control commands
 
 `sky` `power`
 
-`tvguide` `boxoffice` `services` `interactive`
+`tvguide` or `home` `boxoffice` `services` or `search` `interactive` or `sidebar`
 
 `up` `down` `left` `right` `select`
 
 `channelup` `channeldown` `i`
 
-`backup` `text` `help`
+`backup` or `dismiss` `text` `help`
 
 `play` `pause` `rewind` `fastforward` `stop` `record`
 

--- a/sky-remote.js
+++ b/sky-remote.js
@@ -1,13 +1,13 @@
 var net = require('net');
 
-function SkyRemote(host) {
+function SkyRemote(host, port) {
 
 	function sendCommand(code, cb) {
 		var commandBytes = [4,1,0,0,0,0, Math.floor(224 + (code/16)), code % 16];
 
 		var client = net.connect({
 			host: host,
-			port: 49160
+			port: port || 49160
 		});
 
 		var l = 12;
@@ -47,16 +47,22 @@ function SkyRemote(host) {
 
 }
 
+SkyRemote.SKY_Q = 5900;
+
 SkyRemote.commands = {
 	power: 0,
 	select: 1,
 	backup: 2,
+	dismiss: 2,
 	channelup: 6,
 	channeldown: 7,
 	interactive: 8,
+	sidebar: 8,
 	help: 9,
 	services: 10,
+	search: 10,
 	tvguide: 11,
+	home: 11,
 	i: 14,
 	text: 15, 
 	up: 16,


### PR DESCRIPTION
Thanks to the work of @tristan2468 this resolves #4 

The PR should be backwards compatible (untested due to lack of Sky HD box), the constructor function permits an additional field to define the port. For syntactic sugar I've added a value to the SkyRemote function so you can create a SkyRemote by doing:

`let remote = new SkyRemote(ipaddress, SkyRemote.SKY_Q);`