### PR TITLE
Sky Q < 0.60 Firmware legacy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ remoteControl.press('channelup', function(err) {
 });
 
 ```
-### Sky Q
+### Sky Q (if firmware < 060)
 
 ```
-var remoteControl = new SkyRemote('192.168.0.40', SkyRemote.SKY_Q);
+var remoteControl = new SkyRemote('192.168.0.40', SkyRemote.SKY_Q_LEGACY);
 ```
 
 ## Remote control commands

--- a/sky-remote.js
+++ b/sky-remote.js
@@ -65,7 +65,8 @@ function SkyRemote(host, port) {
 
 }
 
-SkyRemote.SKY_Q = 5900;
+SkyRemote.SKY_Q_LEGACY = 5900;
+SkyRemote.SKY_Q = 49160; // Keeping for backwards compatability
 
 SkyRemote.commands = {
 	power: 0,


### PR DESCRIPTION
Saw someone else made a lazy attempt at solving so prompted me to do it properly 

Added SKY_Q_LEGACY option for use with <0.60 firmware. Updated readme to reflect usage. Maintained old SKY_Q variable but with 'new' port to aid in compatibility with existing Sky Q users.